### PR TITLE
Store settings cookie for one year using YUI cookie utility

### DIFF
--- a/src/main/webapp/scripts/services.js
+++ b/src/main/webapp/scripts/services.js
@@ -23,7 +23,11 @@ angular.
 
     service('storage',function ($cookies, buildMonitorName, hashCodeOf) {
         this.persist = function (name, value) {
-            $cookies[prefix(name)] = value;
+            var nextYear = new Date();
+            nextYear.setYear(now.getFullYear()+1);
+            YAHOO.util.Cookie.set(prefix(name), value, {
+                expires: nextYear
+            });
         }
 
         this.retrieve = function (name, defaultValue) {


### PR DESCRIPTION
Here is a proposal to fix the issue of settings cookies that are session bound.

With this change, the settings (number of columns and font size) are persisted across browsers restart. The cookies remain 1 year after the last access, which should be sufficient (and can be easily modified).

It uses the core JS library provided by Jenkins to store the cookie content.

Let me know what you think of this fix.

Best regards,
Reynald
