### PR TITLE
Hide possible culprits on "claimed" builds

### DIFF
--- a/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-jobViews.jelly
+++ b/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-jobViews.jelly
@@ -16,7 +16,7 @@
                 <ul class="description">
                     <li data-ng-show="job.claimed">Claimed by <strong>{{ job.claimAuthor }}</strong>: {{ job.claimReason }}</li>
                 </ul>
-                <ul data-ng-show="job.culprits.size() > 0" class="culprits">
+                <ul ng-if="!job.claimed" data-ng-show="job.culprits.size() > 0" class="culprits">
                     <li data-ng-repeat="name in job.culprits">
                         {{name}}
                     </li>

--- a/src/main/webapp/themes/industrial.css
+++ b/src/main/webapp/themes/industrial.css
@@ -144,17 +144,13 @@ h2 {
     margin: 0 0 0.25em 1em; padding: 0;
     font-size: 1.2em;
 }
-.build-monitor ul#job-views .claimed .meta ul.culprits li {
-    font-size: 1em;
-    margin-top:0.5em;
-}
 
 .build-monitor .meta li { display: inline-block; }
 .build-monitor .meta .culprits li { margin-right:0.5em; }
 .build-monitor .meta .culprits li:after { content: ","; }
 .build-monitor .meta .culprits li:last-child:after { content: ""; }
 
-.build-monitor .failing ul.culprits li:first-child:before {
+.build-monitor ul.culprits li:first-child:before {
     content: "Possible Culprits: ";
 }
 


### PR DESCRIPTION
Ps. Although there is a clear requirement and code to enact it. I didn't know how to write a test (against future refactoring) to assert the visibility of something determined by AngularJS expressions. 

Closes #40
