### PR TITLE
602 stuck in sorry to bother you in kiosk mode

### DIFF
--- a/build-monitor-plugin/src/main/webapp/scripts/services.js
+++ b/build-monitor-plugin/src/main/webapp/scripts/services.js
@@ -67,6 +67,9 @@ angular.
                 ]).open().then(function (result) {
                     $window.location.reload();
                 });
+			setTimeout(function() {
+				$window.location.reload();
+			}, 10000);
         }
     }).
 

--- a/build-monitor-plugin/src/main/webapp/scripts/services.js
+++ b/build-monitor-plugin/src/main/webapp/scripts/services.js
@@ -67,9 +67,9 @@ angular.
                 ]).open().then(function (result) {
                     $window.location.reload();
                 });
-			setTimeout(function() {
-				$window.location.reload();
-			}, 10000);
+            setTimeout(function() {
+                $window.location.reload();
+            }, 10000);
         }
     }).
 


### PR DESCRIPTION
As pointed out in #602 it would be really nice when running in kiosk mode, that the error message automatically try to reload the page. I set it to 10 seconds to not overload the server if several build monitor views are running at the same time.