### PR TITLE
Remove `serenity-maven-plugin`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,3 @@
-buildPlugin(useContainerAgent: true, configurations: [
+buildPlugin(timeout: 120, useContainerAgent: true, configurations: [
     [platform: 'linux', jdk: 17],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,3 @@
-buildPlugin(timeout: 120, useContainerAgent: true, configurations: [
+buildPlugin(useContainerAgent: true, configurations: [
     [platform: 'linux', jdk: 17],
 ])

--- a/build-monitor-acceptance/pom.xml
+++ b/build-monitor-acceptance/pom.xml
@@ -132,25 +132,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>net.serenity-bdd.maven.plugins</groupId>
-        <artifactId>serenity-maven-plugin</artifactId>
-        <version>${serenity.version}</version>
-        <executions>
-          <execution>
-            <id>serenity-reports</id>
-            <goals>
-              <goal>aggregate</goal>
-            </goals>
-            <phase>post-integration-test</phase>
-            <configuration>
-              <generateOutcomes>true</generateOutcomes>
-              <outputDirectory>target/site/serenity</outputDirectory>
-              <sourceDirectory>target/site/serenity</sourceDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
Checking to see if this is what is responsible for the extremely long test collection times on CI builds.