### PR TITLE
Improve casc integration

### DIFF
--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
@@ -27,6 +27,7 @@ import com.smartcodeltd.jenkinsci.plugins.buildmonitor.api.Respond;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.build.GetBuildViewModel;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.facade.StaticJenkinsAPIs;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.installation.BuildMonitorInstallation;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.order.BaseOrder;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobViews;
 import hudson.Extension;
@@ -43,6 +44,7 @@ import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
 
@@ -155,6 +157,15 @@ public class BuildMonitorView extends ListView {
 
     @Override
     protected void initColumns() {}
+
+    @DataBoundSetter
+    public void setConfig(Config config) {
+        this.config = config;
+    }
+
+    public Config getConfig() {
+        return currentConfig();
+    }
 
     @Override
     protected void submit(StaplerRequest req) throws ServletException, IOException, FormException {
@@ -276,17 +287,18 @@ public class BuildMonitorView extends ListView {
     // If an older version of config.xml is loaded, "config" field is missing, but "order" is present
     private void migrateFromOldToNewConfigFormat() {
         Config c = new Config();
-        c.setOrder(order);
+
+        c.setOrder((BaseOrder) order);
 
         config = c;
         order = null;
     }
 
     @SuppressWarnings("unchecked")
-    private Comparator<Job<?, ?>> orderIn(String requestedOrdering) throws ReflectiveOperationException {
+    private BaseOrder orderIn(String requestedOrdering) throws ReflectiveOperationException {
         String packageName = this.getClass().getPackage().getName() + ".order.";
 
-        return (Comparator<Job<?, ?>>) Class.forName(packageName + requestedOrdering)
+        return (BaseOrder) Class.forName(packageName + requestedOrdering)
                 .getDeclaredConstructor()
                 .newInstance();
     }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
@@ -2,12 +2,21 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor;
 
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.build.GetBuildViewModel;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.build.GetLastBuild;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.order.BaseOrder;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.order.ByName;
+import hudson.Extension;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
 import hudson.model.Job;
 import java.util.Comparator;
 import java.util.Optional;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
 
-public class Config {
+public class Config implements Describable<Config> {
+
+    @Extension
+    public static class ConfigDescriptor extends Descriptor<Config> {}
 
     private Boolean colourBlindMode;
     private Boolean displayCommitters;
@@ -24,6 +33,14 @@ public class Config {
         return new Config();
     }
 
+    @Override
+    public Descriptor<Config> getDescriptor() {
+        return Jenkins.get().getDescriptor(this.getClass());
+    }
+
+    @DataBoundConstructor
+    public Config() {}
+
     public Comparator<Job<?, ?>> getOrder() {
         /*
          * Jenkins unmarshals objects from config.xml by setting their private fields directly and without invoking their constructors.
@@ -36,7 +53,7 @@ public class Config {
         return Optional.ofNullable(order).orElse(new ByName());
     }
 
-    public void setOrder(Comparator<Job<?, ?>> order) {
+    public void setOrder(BaseOrder order) {
         this.order = order;
     }
 
@@ -155,5 +172,5 @@ public class Config {
         UserSetting
     }
 
-    private Comparator<Job<?, ?>> order;
+    private BaseOrder order;
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/build/GetBuildViewModel.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/build/GetBuildViewModel.java
@@ -2,8 +2,16 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.build;
 
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.BuildViewModel;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
 
-public interface GetBuildViewModel {
+public interface GetBuildViewModel extends Describable<GetBuildViewModel> {
 
     BuildViewModel from(JobView job);
+
+    @Override
+    public default Descriptor<GetBuildViewModel> getDescriptor() {
+        return Jenkins.get().getDescriptor(this.getClass());
+    }
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/build/GetLastBuild.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/build/GetLastBuild.java
@@ -2,6 +2,9 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.build;
 
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.BuildViewModel;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 public class GetLastBuild implements GetBuildViewModel {
 
@@ -9,4 +12,10 @@ public class GetLastBuild implements GetBuildViewModel {
     public BuildViewModel from(JobView job) {
         return job.lastBuild();
     }
+
+    @DataBoundConstructor
+    public GetLastBuild() {}
+
+    @Extension
+    public static class GetLastCompletedBuildDescriptor extends Descriptor<GetBuildViewModel> {}
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/build/GetLastCompletedBuild.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/build/GetLastCompletedBuild.java
@@ -2,6 +2,9 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.build;
 
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.BuildViewModel;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 public class GetLastCompletedBuild implements GetBuildViewModel {
 
@@ -9,4 +12,10 @@ public class GetLastCompletedBuild implements GetBuildViewModel {
     public BuildViewModel from(JobView job) {
         return job.lastCompletedBuild();
     }
+
+    @DataBoundConstructor
+    public GetLastCompletedBuild() {}
+
+    @Extension
+    public static class GetLastCompletedBuildDescriptor extends Descriptor<GetBuildViewModel> {}
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/BaseOrder.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/BaseOrder.java
@@ -1,0 +1,15 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.order;
+
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.model.Job;
+import java.util.Comparator;
+import jenkins.model.Jenkins;
+
+public abstract class BaseOrder implements Describable<BaseOrder>, Comparator<Job<?, ?>> {
+
+    @Override
+    public Descriptor<BaseOrder> getDescriptor() {
+        return Jenkins.get().getDescriptor(this.getClass());
+    }
+}

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByDisplayName.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByDisplayName.java
@@ -1,12 +1,22 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.order;
 
+import hudson.Extension;
+import hudson.model.Descriptor;
 import hudson.model.Job;
 import java.io.Serializable;
 import java.util.Comparator;
+import org.kohsuke.stapler.DataBoundConstructor;
 
-public class ByDisplayName implements Comparator<Job<?, ?>>, Serializable {
+public class ByDisplayName extends BaseOrder implements Comparator<Job<?, ?>>, Serializable {
+
+    @DataBoundConstructor
+    public ByDisplayName() {}
+
     @Override
     public int compare(Job<?, ?> a, Job<?, ?> b) {
         return a.getDisplayName().compareToIgnoreCase(b.getDisplayName());
     }
+
+    @Extension
+    public static class ByDisplayNameDescriptor extends Descriptor<BaseOrder> {}
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByEstimatedDuration.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByEstimatedDuration.java
@@ -1,15 +1,22 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.order;
 
+import hudson.Extension;
 import hudson.model.AbstractProject;
+import hudson.model.Descriptor;
+import hudson.model.Job;
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
+import org.kohsuke.stapler.DataBoundConstructor;
 
-public class ByEstimatedDuration implements Comparator<AbstractProject<?, ?>>, Serializable {
+public class ByEstimatedDuration extends BaseOrder implements Comparator<Job<?, ?>>, Serializable {
+
+    @DataBoundConstructor
+    public ByEstimatedDuration() {}
 
     @Override
-    public int compare(AbstractProject<?, ?> a, AbstractProject<?, ?> b) {
-        return compareEstimatedDuration(a, b);
+    public int compare(Job<?, ?> a, Job<?, ?> b) {
+        return compareEstimatedDuration((AbstractProject<?, ?>) a, (AbstractProject<?, ?>) b);
     }
 
     /**
@@ -32,4 +39,7 @@ public class ByEstimatedDuration implements Comparator<AbstractProject<?, ?>>, S
     private int compareEstimatedDuration(AbstractProject<?, ?> a, AbstractProject<?, ?> b) {
         return Long.compare(getTotalEstimatedDuration(a), getTotalEstimatedDuration(b));
     }
+
+    @Extension
+    public static class ByEstimatedDurationDescriptor extends Descriptor<BaseOrder> {}
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByFullName.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByFullName.java
@@ -1,12 +1,22 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.order;
 
+import hudson.Extension;
+import hudson.model.Descriptor;
 import hudson.model.Job;
 import java.io.Serializable;
 import java.util.Comparator;
+import org.kohsuke.stapler.DataBoundConstructor;
 
-public class ByFullName implements Comparator<Job<?, ?>>, Serializable {
+public class ByFullName extends BaseOrder implements Comparator<Job<?, ?>>, Serializable {
+
+    @DataBoundConstructor
+    public ByFullName() {}
+
     @Override
     public int compare(Job<?, ?> a, Job<?, ?> b) {
         return a.getFullName().compareToIgnoreCase(b.getFullName());
     }
+
+    @Extension
+    public static class ByFullNameDescriptor extends Descriptor<BaseOrder> {}
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByLastBuildTime.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByLastBuildTime.java
@@ -1,14 +1,20 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.order;
 
+import hudson.Extension;
+import hudson.model.Descriptor;
 import hudson.model.Job;
 import java.io.Serializable;
 import java.util.Comparator;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * Inspired by <a href="https://github.com/Mercynary">@Mercenary</a>'s answer to
  * issue <a href="https://github.com/jenkinsci/build-monitor-plugin/issues/113">#113</a>.
  */
-public class ByLastBuildTime implements Comparator<Job<?, ?>>, Serializable {
+public class ByLastBuildTime extends BaseOrder implements Comparator<Job<?, ?>>, Serializable {
+
+    @DataBoundConstructor
+    public ByLastBuildTime() {}
 
     @Override
     public int compare(Job<?, ?> a, Job<?, ?> b) {
@@ -31,4 +37,7 @@ public class ByLastBuildTime implements Comparator<Job<?, ?>>, Serializable {
         // "New is always better" - B. Stinson ;-)
         return b.getLastBuild().getTimestamp().compareTo(a.getLastBuild().getTimestamp());
     }
+
+    @Extension
+    public static class ByLastBuildTimeDescriptor extends Descriptor<BaseOrder> {}
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByName.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByName.java
@@ -1,12 +1,22 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.order;
 
+import hudson.Extension;
+import hudson.model.Descriptor;
 import hudson.model.Job;
 import java.io.Serializable;
 import java.util.Comparator;
+import org.kohsuke.stapler.DataBoundConstructor;
 
-public class ByName implements Comparator<Job<?, ?>>, Serializable {
+public class ByName extends BaseOrder implements Comparator<Job<?, ?>>, Serializable {
+
+    @DataBoundConstructor
+    public ByName() {}
+
     @Override
     public int compare(Job<?, ?> a, Job<?, ?> b) {
         return a.getName().compareToIgnoreCase(b.getName());
     }
+
+    @Extension
+    public static class ByNameDescriptor extends Descriptor<BaseOrder> {}
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByStatus.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByStatus.java
@@ -1,12 +1,19 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.order;
 
+import hudson.Extension;
+import hudson.model.Descriptor;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
 import java.io.Serializable;
 import java.util.Comparator;
+import org.kohsuke.stapler.DataBoundConstructor;
 
-public class ByStatus implements Comparator<Job<?, ?>>, Serializable {
+public class ByStatus extends BaseOrder implements Comparator<Job<?, ?>>, Serializable {
+
+    @DataBoundConstructor
+    public ByStatus() {}
+
     @Override
     public int compare(Job<?, ?> a, Job<?, ?> b) {
         return bothProjectsHaveBuildHistory(a, b) ? compareRecentlyCompletedBuilds(a, b) : compareProjects(a, b);
@@ -49,4 +56,7 @@ public class ByStatus implements Comparator<Job<?, ?>>, Serializable {
             return 0;
         }
     }
+
+    @Extension
+    public static class ByStatusDescriptor extends Descriptor<BaseOrder> {}
 }

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/jcasc/ConfigurationAsCodeTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/jcasc/ConfigurationAsCodeTest.java
@@ -2,8 +2,17 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.jcasc;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.Is.isA;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+import java.util.Collection;
+
+import org.junit.ClassRule;
+import org.junit.Test;
 
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.order.ByStatus;
+
 import hudson.model.View;
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorRegistry;
@@ -11,10 +20,7 @@ import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.misc.Util;
 import io.jenkins.plugins.casc.model.CNode;
-import java.util.Collection;
 import jenkins.model.Jenkins;
-import org.junit.ClassRule;
-import org.junit.Test;
 
 public class ConfigurationAsCodeTest {
 
@@ -33,6 +39,9 @@ public class ConfigurationAsCodeTest {
         assertThat(view.getIncludeRegex(), is(".+\\/(my-job-.*)\\/(master|demo)"));
         assertThat(view.getViewName(), is("My-Monitor"));
         assertThat(view.isRecurse(), is(true));
+        assertThat(view.getConfig(), notNullValue());
+        assertThat(view.getConfig().getOrder(), isA(ByStatus.class));
+        assertThat(view.getConfig().getMaxColumns(), is(3));
     }
 
     @Test

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/jcasc/ConfigurationAsCodeTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/jcasc/ConfigurationAsCodeTest.java
@@ -5,14 +5,8 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.Is.isA;
 import static org.hamcrest.core.IsNull.notNullValue;
 
-import java.util.Collection;
-
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.order.ByStatus;
-
 import hudson.model.View;
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorRegistry;
@@ -20,7 +14,10 @@ import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.misc.Util;
 import io.jenkins.plugins.casc.model.CNode;
+import java.util.Collection;
 import jenkins.model.Jenkins;
+import org.junit.ClassRule;
+import org.junit.Test;
 
 public class ConfigurationAsCodeTest {
 

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/ConfigStateRecipe.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/ConfigStateRecipe.java
@@ -2,6 +2,7 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar
 
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.Config;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.build.GetLastCompletedBuild;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.order.BaseOrder;
 import hudson.model.Job;
 import java.util.Comparator;
 import java.util.function.Supplier;
@@ -11,7 +12,7 @@ public class ConfigStateRecipe implements Supplier<Config> {
     private Config config = Config.defaultConfig();
 
     public ConfigStateRecipe order(Comparator<Job<?, ?>> order) {
-        config.setOrder(order);
+        config.setOrder((BaseOrder) order);
 
         return this;
     }

--- a/build-monitor-plugin/src/test/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/jcasc/configuration-as-code-expected.yml
+++ b/build-monitor-plugin/src/test/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/jcasc/configuration-as-code-expected.yml
@@ -1,4 +1,8 @@
 - buildMonitor:
+    config:
+      displayBadgesFrom: "getLastBuild"
+      maxColumns: 3
+      order: "byStatus"
     includeRegex: ".+\\/(my-job-.*)\\/(master|demo)"
     name: "My-Monitor"
     recurse: true

--- a/build-monitor-plugin/src/test/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/jcasc/configuration-as-code.yml
+++ b/build-monitor-plugin/src/test/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/jcasc/configuration-as-code.yml
@@ -5,3 +5,6 @@ jenkins:
         name: "My-Monitor"
         recurse: true
         title: "My Monitor"
+        config:
+          maxColumns: 3
+          order: "byStatus"


### PR DESCRIPTION
Whenever we restart our instance of jenkins, order of tiles in our views is reverted to byName which is quite annoying. This PR fixes this and resolves issue #491 by serialising Config class into yaml configuration.

To achieve it I have:
- Added DataBoundSetter for Config in BuildMonitorView
- Added shared baseClass for defined comparators
- Added descriptors for Config, BaseOrder and GetBulidViewModel


### Testing done

Manual test using hpi plugin have been done. I have created new view and saved its configuration using casc to verify that required values are present in yaml. I have also added new fields to existing casc test. If this feature needs additional tests to be written I am willing to do so.


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
