### PR TITLE
Improve casc integration - boolean flags in config

### DIFF
--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
@@ -95,7 +95,7 @@ public class BuildMonitorView extends ListView {
 
     @SuppressWarnings("unused") // used in the configure-entries.jelly form
     public boolean isDisplayCommitters() {
-        return currentConfig().shouldDisplayCommitters();
+        return currentConfig().getDisplayCommitters();
     }
 
     // used in the configure-entries.jelly and main-settings.jelly forms
@@ -113,19 +113,19 @@ public class BuildMonitorView extends ListView {
     // used in the configure-entries.jelly and main-settings.jelly forms
     @SuppressWarnings("unused")
     public boolean isColourBlindMode() {
-        return currentConfig().colourBlindMode();
+        return currentConfig().getColourBlindMode();
     }
 
     // used in the configure-entries.jelly and main-settings.jelly forms
     @SuppressWarnings("unused")
     public boolean isReduceMotion() {
-        return currentConfig().reduceMotion();
+        return currentConfig().getReduceMotion();
     }
 
     // used in the configure-entries.jelly and main-settings.jelly forms
     @SuppressWarnings("unused")
     public boolean isShowBadges() {
-        return currentConfig().showBadges();
+        return currentConfig().getShowBadges();
     }
 
     @SuppressWarnings("unused") // used in the configure-entries.jelly form
@@ -140,7 +140,7 @@ public class BuildMonitorView extends ListView {
 
     @SuppressWarnings("unused") // used in the configure-entries.jelly form
     public boolean isDisplayJUnitProgress() {
-        return currentConfig().shouldDisplayJUnitProgress();
+        return currentConfig().getDisplayJUnitProgress();
     }
 
     private static final BuildMonitorInstallation installation = new BuildMonitorInstallation();

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
@@ -66,7 +66,7 @@ public class Config implements Describable<Config> {
                 BuildFailureAnalyzerDisplayedField.valueOf(buildFailureAnalyzerDisplayedField);
     }
 
-    public boolean colourBlindMode() {
+    public boolean getColourBlindMode() {
         return Optional.ofNullable(colourBlindMode).orElse(false);
     }
 
@@ -74,7 +74,7 @@ public class Config implements Describable<Config> {
         this.colourBlindMode = flag;
     }
 
-    public boolean shouldDisplayCommitters() {
+    public boolean getDisplayCommitters() {
         return Optional.ofNullable(displayCommitters).orElse(true);
     }
 
@@ -82,7 +82,7 @@ public class Config implements Describable<Config> {
         this.displayCommitters = flag;
     }
 
-    public boolean reduceMotion() {
+    public boolean getReduceMotion() {
         return Optional.ofNullable(reduceMotion).orElse(false);
     }
 
@@ -90,7 +90,7 @@ public class Config implements Describable<Config> {
         this.reduceMotion = flag;
     }
 
-    public boolean showBadges() {
+    public boolean getShowBadges() {
         return Optional.ofNullable(showBadges).orElse(true);
     }
 
@@ -114,7 +114,7 @@ public class Config implements Describable<Config> {
         this.displayBadgesFrom = displayBadgesFrom;
     }
 
-    public boolean shouldDisplayJUnitProgress() {
+    public boolean getDisplayJUnitProgress() {
         return Optional.ofNullable(displayJUnitProgress).orElse(true);
     }
 

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViews.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViews.java
@@ -40,7 +40,7 @@ public class JobViews {
 
         // todo: a more elegant way of assembling the features would be nice
         viewFeatures.add(new HasConfig(config));
-        viewFeatures.add(new HasHeadline(new HeadlineConfig(config.shouldDisplayCommitters())));
+        viewFeatures.add(new HasHeadline(new HeadlineConfig(config.getDisplayCommitters())));
         viewFeatures.add(new KnowsLastCompletedBuildDetails());
         viewFeatures.add(new KnowsCurrentBuildsDetails());
 
@@ -58,7 +58,7 @@ public class JobViews {
             }
         }
 
-        if (config.shouldDisplayJUnitProgress() && jenkins.hasPlugin(Junit_Realtime)) {
+        if (config.getDisplayJUnitProgress() && jenkins.hasPlugin(Junit_Realtime)) {
             viewFeatures.add(new HasJunitRealtime());
         }
 

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/jcasc/ConfigurationAsCodeTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/jcasc/ConfigurationAsCodeTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.core.Is.isA;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.build.GetLastBuild;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.order.ByStatus;
 import hudson.model.View;
 import io.jenkins.plugins.casc.ConfigurationContext;
@@ -37,8 +38,14 @@ public class ConfigurationAsCodeTest {
         assertThat(view.getViewName(), is("My-Monitor"));
         assertThat(view.isRecurse(), is(true));
         assertThat(view.getConfig(), notNullValue());
-        assertThat(view.getConfig().getOrder(), isA(ByStatus.class));
+        assertThat(view.getConfig().getColourBlindMode(), is(true));
+        assertThat(view.getConfig().getDisplayBadgesFrom(), isA(GetLastBuild.class));
+        assertThat(view.getConfig().getDisplayCommitters(), is(false));
+        assertThat(view.getConfig().getDisplayJUnitProgress(), is(false));
         assertThat(view.getConfig().getMaxColumns(), is(3));
+        assertThat(view.getConfig().getOrder(), isA(ByStatus.class));
+        assertThat(view.getConfig().getReduceMotion(), is(true));
+        assertThat(view.getConfig().getShowBadges(), is(false));
     }
 
     @Test

--- a/build-monitor-plugin/src/test/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/jcasc/configuration-as-code-expected.yml
+++ b/build-monitor-plugin/src/test/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/jcasc/configuration-as-code-expected.yml
@@ -1,8 +1,13 @@
 - buildMonitor:
     config:
+      colourBlindMode: true
       displayBadgesFrom: "getLastBuild"
+      displayCommitters: false
+      displayJUnitProgress: false
       maxColumns: 3
       order: "byStatus"
+      reduceMotion: true
+      showBadges: false
     includeRegex: ".+\\/(my-job-.*)\\/(master|demo)"
     name: "My-Monitor"
     recurse: true

--- a/build-monitor-plugin/src/test/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/jcasc/configuration-as-code.yml
+++ b/build-monitor-plugin/src/test/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/jcasc/configuration-as-code.yml
@@ -8,3 +8,8 @@ jenkins:
         config:
           maxColumns: 3
           order: "byStatus"
+          displayCommitters: false
+          colourBlindMode: true
+          reduceMotion: true
+          displayJUnitProgress: false
+          showBadges: false


### PR DESCRIPTION
 Config class uses non-standard getter names which causes casc to not consider some of the fields when creating and parsing yaml configuration. I discovered it when we decided to switch off "displayCommitters" option on our instance. 
Issues raised in #491 which got me to creating my previous PR #787 are fixed, but it can be considered follow-up since I haven't opened separate issue and it expands serialising of the same class.

### Testing done

Fixed test config and manual test.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
