### PR TITLE
[JENKINS-60866][JENKINS-71513] Adapt to upcoming `st:bind` change

### DIFF
--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/index.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/index.jelly
@@ -158,8 +158,9 @@
                 };
                 window.bindings={};
             </script>
-            <st:bind var="window.bindings['buildMonitor']" value="${it}" />
+            <st:bind var="buildMonitorBind" value="${it}" />
             <script>
+                window.bindings['buildMonitor'] = buildMonitorBind
                 window.makeStaplerProxy = window.originalMakeStaplerProxy;
                 try {
                     delete window.originalMakeStaplerProxy;


### PR DESCRIPTION
Related to https://github.com/jenkinsci/stapler/pull/385 and https://github.com/jenkinsci/jenkins/pull/6865.

This is not strictly required, as Stapler/Jenkins will continue to work as before even with the existing code, but this PR demonstrates the change in behavior (without this change, it's the backward compatibility mode, with this change it's the new behavior).

Currently this tag emits something like the following when running on the core PR build:
```
<script>window.bindings['buildMonitor']=makeStaplerProxy('/jenkins/$stapler/bound/<UUID>','<CSRF_CRUMB>',['fetchJobViews']);</script>
```

With this change, on the Jenkins PR build, it's instead
```
<script src="/jenkins/$stapler/bound/script/jenkins/$stapler/bound/<UUID>?var=buildMonitorBind&amp;methods=fetchJobViews" type="application/javascript"></script>
```

(Behavior changes based on whether `var` is a legal identifier or not, and it's not without the PR.)

This does not result in the rest of this plugin (or even this file) becoming compatible with https://plugins.jenkins.io/csp/ or whatever form that'll take in Jenkins core in the future, but that's beyond the scope of this PR.

### Testing done

Opened a BM view and the Stapler proxy calls happened periodically, both with and without this change, when running the core PR incremental build.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
