### PR TITLE
[SECURITY-3280] Address XSS by removing some inline Jelly in JS

### DIFF
--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/index.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/index.jelly
@@ -88,6 +88,7 @@
         <body class="build-monitor dashboard industrial"
               data-ng-app="buildMonitor"
               data-ng-controller="JobViews"
+              data-display-name="${it.displayName}"
               data-ng-class="{ 'colour-blind-mode': settings.colourBlind == 1, 'reduce-motion-mode': settings.reduceMotion == 1 }">
 
             <header>
@@ -198,7 +199,7 @@
                         proxyProvider.configureProxiesUsing(window.bindings);
 
                         cookieJarProvider.describe({
-                            label:     'buildMonitor.' + hashCodeOf('${it.displayName}'),
+                            label:     'buildMonitor.' + hashCodeOf(document.body.dataset.displayName),
                             shelfLife: 365
                         });
                     });


### PR DESCRIPTION
Address https://www.jenkins.io/security/advisory/2024-03-06/#SECURITY-3280

Resolves #942

Docs applied: https://www.jenkins.io/doc/developer/security/xss-prevention/#passing-values-to-javascript

I could have cleaned up other fields in a similar manner, but they're not required to resolve the security issue and I'd prefer to not touch the usage stats code.

### Testing done

XSS before. No XSS after.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
