### PR TITLE
[JENKINS-74067] Extract inline JavaScript from `BuildMonitorView/index.jelly`

### DIFF
--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/collect-usage-stats.js
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/collect-usage-stats.js
@@ -1,31 +1,33 @@
-window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+window.addEventListener("DOMContentLoaded", () => {
+    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
 
-const {
-    buildMonitorVersion,
-    jenkinsVersion,
-    installationSize,
-    itemsSize,
-    installationAudience,
-    anonymousCorrelationId
-} = document.querySelector('.build-monitor-ga-data-holder').dataset;
+    const {
+        buildMonitorVersion,
+        jenkinsVersion,
+        installationSize,
+        itemsSize,
+        installationAudience,
+        anonymousCorrelationId
+    } = document.querySelector('.build-monitor-ga-data-holder').dataset;
 
-ga('create', 'UA-61694827-4', 'auto', {
-    'userId': anonymousCorrelationId,
-    'sampleRate': 1
+    ga('create', 'UA-61694827-4', 'auto', {
+        'userId': anonymousCorrelationId,
+        'sampleRate': 1
+    });
+
+    ga('set', {
+        'forceSSL': true,
+        'appName': 'Build Monitor',
+        'appId': 'build-monitor-plugin',
+
+        'appVersion': buildMonitorVersion,
+        'appInstallerId': jenkinsVersion,
+
+        'dimension1': installationSize,
+        'dimension2': itemsSize,
+        'dimension3': installationAudience,
+        'dimension4': anonymousCorrelationId
+    });
+
+    ga('send', 'screenview', {screenName: 'Dashboard'});
 });
-
-ga('set', {
-    'forceSSL': true,
-    'appName': 'Build Monitor',
-    'appId': 'build-monitor-plugin',
-
-    'appVersion': buildMonitorVersion,
-    'appInstallerId': jenkinsVersion,
-
-    'dimension1': installationSize,
-    'dimension2': itemsSize,
-    'dimension3': installationAudience,
-    'dimension4': anonymousCorrelationId
-});
-
-ga('send', 'screenview', {screenName: 'Dashboard'});

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/collect-usage-stats.js
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/collect-usage-stats.js
@@ -1,0 +1,31 @@
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+
+const {
+    buildMonitorVersion,
+    jenkinsVersion,
+    installationSize,
+    itemsSize,
+    installationAudience,
+    anonymousCorrelationId
+} = document.querySelector('.build-monitor-ga-data-holder').dataset;
+
+ga('create', 'UA-61694827-4', 'auto', {
+    'userId': anonymousCorrelationId,
+    'sampleRate': 1
+});
+
+ga('set', {
+    'forceSSL': true,
+    'appName': 'Build Monitor',
+    'appId': 'build-monitor-plugin',
+
+    'appVersion': buildMonitorVersion,
+    'appInstallerId': jenkinsVersion,
+
+    'dimension1': installationSize,
+    'dimension2': itemsSize,
+    'dimension3': installationAudience,
+    'dimension4': anonymousCorrelationId
+});
+
+ga('send', 'screenview', {screenName: 'Dashboard'});

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/index.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/index.jelly
@@ -55,13 +55,6 @@
             <script src="${resourcesURL}/vendor/angular-slider-5.4.0/rzslider.min.js"></script>
 
             <j:if test="${it.collectAnonymousUsageStatistics()}">
-                <span class="build-monitor-ga-data-holder"
-                        data-build-monitor-version="${it.installation.buildMonitorVersion()}"
-                        data-jenkins-version="${h.version}"
-                        data-installation-size="${it.installation.size()}"
-                        data-items-size="${it.items.size()}"
-                        data-installation-audience="${it.installation.audience()}"
-                        data-anonymous-correlation-id="${it.installation.anonymousCorrelationId()}"/>
                 <st:adjunct includes="com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView.collect-usage-stats"/>
                 <script async="async" src='//www.google-analytics.com/analytics.js'></script>
             </j:if>
@@ -76,6 +69,15 @@
                 <a class="home-link" href="${rootURL}/" title="Jenkins">Jenkins</a>
                 <h1><a href="configure" title="Configure the '${it.title}' view">${it.title}</a></h1>
                 <st:include page="main-settings.jelly"/>
+                <j:if test="${it.collectAnonymousUsageStatistics()}">
+                    <span class="build-monitor-ga-data-holder"
+                          data-build-monitor-version="${it.installation.buildMonitorVersion()}"
+                          data-jenkins-version="${h.version}"
+                          data-installation-size="${it.installation.size()}"
+                          data-items-size="${it.items.size()}"
+                          data-installation-audience="${it.installation.audience()}"
+                          data-anonymous-correlation-id="${it.installation.anonymousCorrelationId()}"/>
+                </j:if>
             </header>
 
             <j:choose>

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/index.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/index.jelly
@@ -55,30 +55,14 @@
             <script src="${resourcesURL}/vendor/angular-slider-5.4.0/rzslider.min.js"></script>
 
             <j:if test="${it.collectAnonymousUsageStatistics()}">
-                <script>
-                    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-
-                    ga('create', 'UA-61694827-4', 'auto', {
-                        'userId':     '${it.installation.anonymousCorrelationId()}',
-                        'sampleRate': 1
-                    });
-
-                    ga('set', {
-                        'forceSSL':       true,
-                        'appName':        'Build Monitor',
-                        'appId':          'build-monitor-plugin',
-
-                        'appVersion':     '${it.installation.buildMonitorVersion()}',
-                        'appInstallerId': '${h.version}',
-
-                        'dimension1':     '${it.installation.size()}',
-                        'dimension2':     '${it.items.size()}',
-                        'dimension3':     '${it.installation.audience()}',
-                        'dimension4':     '${it.installation.anonymousCorrelationId()}'
-                    });
-
-                    ga('send', 'screenview', {screenName: 'Dashboard'});
-                </script>
+                <span class="build-monitor-ga-data-holder"
+                        data-build-monitor-version="${it.installation.buildMonitorVersion()}"
+                        data-jenkins-version="${h.version}"
+                        data-installation-size="${it.installation.size()}"
+                        data-items-size="${it.items.size()}"
+                        data-installation-audience="${it.installation.audience()}"
+                        data-anonymous-correlation-id="${it.installation.anonymousCorrelationId()}"/>
+                <st:adjunct includes="com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView.collect-usage-stats"/>
                 <script async="async" src='//www.google-analytics.com/analytics.js'></script>
             </j:if>
         </head>
@@ -128,44 +112,9 @@
                 </div>
             </footer>
 
-            <script>
-                /*
-                 * todo: (13.08.2013) Replace the below workaround with a custom Jelly tag (ExposeBindTag)
-                 *   extending either org.kohsuke.stapler.jelly.BindTag or AbstractStaplerTag,
-                 *   that would supersede currently defective BindTag implementation:
-                 *   - https://groups.google.com/forum/#!topic/jenkinsci-dev/S9bhX4ts0g4
-                 *   - https://issues.jenkins-ci.org/browse/JENKINS-18641
-                 *
-                 *   Defect in BindTag manifests itself by causing a JavaScript error and preventing scripts after
-                 *   the &lt;st:bind&gt; invocation from executing, which results in an "empty Build Monitor".
-                 *   The issue occurs on Jenkins 1.521-1.526, only if the jQuery plugin is used.
-                 *
-                 * Motivation behind a custom Jelly tag:
-                 *   Original implementation of the BindTag doesn't provide an easy way of handling AJAX errors,
-                 *   which may happen if a network connection is lost or when Jenkins is restarted (which then makes
-                 *   Stapler's binding hash obsolete and Jenkins return 404 for any subsequent requests).
-                 *
-                 *   Custom Jelly tag should generate a JSON object exposing the binding, leaving the implementation
-                 *   of the proxy to the Developer. It makes more sense for a developer to require a binding adapter
-                 *   implementation specific to their JavaScript framework of choice, rather than for Stapler to try
-                 *   to predict what JavaScript libraries will ever be used with it in the future...
-                 */
-                window.originalMakeStaplerProxy = window.makeStaplerProxy;
-                window.makeStaplerProxy = function(url, crumb, methods) {
-                    return { url: url, crumb: crumb, methods: methods }
-                };
-                window.bindings={};
-            </script>
+            <st:adjunct includes="com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView.replace-stapler-proxy"/>
             <st:bind var="buildMonitorBind" value="${it}" />
-            <script>
-                window.bindings['buildMonitor'] = buildMonitorBind
-                window.makeStaplerProxy = window.originalMakeStaplerProxy;
-                try {
-                    delete window.originalMakeStaplerProxy;
-                } catch(e) {
-                    window["originalMakeStaplerProxy"] = undefined;
-                }
-            </script>
+            <st:adjunct includes="com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView.restore-stapler-proxy"/>
 
             <!-- todo: use require.js and bundle it all up -->
             <script src="${resourcesURL}/scripts/app.js"></script>
@@ -180,26 +129,11 @@
             <script src="${resourcesURL}/scripts/expansions/build-number.js"></script>
             <script src="${resourcesURL}/scripts/expansions/build-time.js"></script>
             <script src="${resourcesURL}/scripts/slot.js"></script>
-            <script>
-                'use strict';
 
-                angular.
-
-                    module('buildMonitor').
-
-                    constant('BUILD_MONITOR_VERSION', '${it.installation.buildMonitorVersion()}').
-                    constant('CSRF_CRUMB_FIELD_NAME', '${it.csrfCrumbFieldName}').
-
-                    config(function(proxyProvider, cookieJarProvider, hashCodeProvider) {
-                        var hashCodeOf = hashCodeProvider.hashCodeOf;
-
-                        proxyProvider.configureProxiesUsing(window.bindings);
-
-                        cookieJarProvider.describe({
-                            label:     'buildMonitor.' + hashCodeOf(document.body.dataset.displayName)
-                        });
-                    });
-            </script>
+            <span class="build-monitor-data-holder" 
+                  data-build-monitor-version="${it.installation.buildMonitorVersion()}"
+                  data-csrf-crumb-field-name="${it.csrfCrumbFieldName}"/>
+            <st:adjunct includes="com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView.init-build-monitor"/>
         </body>
     </html>
 </j:jelly>

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/init-build-monitor.js
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/init-build-monitor.js
@@ -1,0 +1,19 @@
+'use strict';
+
+(function() {
+    const { buildMonitorVersion, csrfCrumbFieldName } = document.querySelector(".build-monitor-data-holder").dataset;
+
+    angular
+        .module('buildMonitor')
+        .constant('BUILD_MONITOR_VERSION', buildMonitorVersion)
+        .constant('CSRF_CRUMB_FIELD_NAME', csrfCrumbFieldName)
+        .config(function(proxyProvider, cookieJarProvider, hashCodeProvider) {
+        var hashCodeOf = hashCodeProvider.hashCodeOf;
+
+        proxyProvider.configureProxiesUsing(window.bindings);
+
+        cookieJarProvider.describe({
+            label: 'buildMonitor.' + hashCodeOf(document.body.dataset.displayName)
+        });
+    });
+})();

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/replace-stapler-proxy.js
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/replace-stapler-proxy.js
@@ -1,0 +1,26 @@
+/*
+ * todo: (13.08.2013) Replace the below workaround with a custom Jelly tag (ExposeBindTag)
+ *   extending either org.kohsuke.stapler.jelly.BindTag or AbstractStaplerTag,
+ *   that would supersede currently defective BindTag implementation:
+ *   - https://groups.google.com/forum/#!topic/jenkinsci-dev/S9bhX4ts0g4
+ *   - https://issues.jenkins-ci.org/browse/JENKINS-18641
+ *
+ *   Defect in BindTag manifests itself by causing a JavaScript error and preventing scripts after
+ *   the &lt;st:bind&gt; invocation from executing, which results in an "empty Build Monitor".
+ *   The issue occurs on Jenkins 1.521-1.526, only if the jQuery plugin is used.
+ *
+ * Motivation behind a custom Jelly tag:
+ *   Original implementation of the BindTag doesn't provide an easy way of handling AJAX errors,
+ *   which may happen if a network connection is lost or when Jenkins is restarted (which then makes
+ *   Stapler's binding hash obsolete and Jenkins return 404 for any subsequent requests).
+ *
+ *   Custom Jelly tag should generate a JSON object exposing the binding, leaving the implementation
+ *   of the proxy to the Developer. It makes more sense for a developer to require a binding adapter
+ *   implementation specific to their JavaScript framework of choice, rather than for Stapler to try
+ *   to predict what JavaScript libraries will ever be used with it in the future...
+ */
+window.originalMakeStaplerProxy = window.makeStaplerProxy;
+window.makeStaplerProxy = function(url, crumb, methods) {
+    return { url, crumb, methods }
+};
+window.bindings = {};

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/restore-stapler-proxy.js
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/restore-stapler-proxy.js
@@ -1,0 +1,7 @@
+window.bindings['buildMonitor'] = buildMonitorBind;
+window.makeStaplerProxy = window.originalMakeStaplerProxy;
+try {
+    delete window.originalMakeStaplerProxy;
+} catch(e) {
+    window["originalMakeStaplerProxy"] = undefined;
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-74067

### Testing done
[Content Security Policy](https://plugins.jenkins.io/csp/) does not catch the violations on pages without `l:layout`, so I'm not relying on it here. I've tried manually adding the header on top of the file by adding the following:
```xml
<st:setHeader name="Content-Security-Policy"
                  value="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: ; script-src 'self' 'report-sample' usage.jenkins.io www.google-analytics.com api.github.com;"/>
```
Page obviously just falls apart with that header set because of inline scripts. 
On the screen recording I'm demonstrating the replacement of `makeStaplerProxy` by the plugin (for whetaver reason it needs it, angularJS I guess), and showing plugin's basic behaviour like monitoring build statuses and showing build progress.

[Before the fix](https://www.youtube.com/watch?v=9D36FkP_Cc4)

With the fix we're able to set the CSP rule as shown above and test with it. I've demonstrated that `makeStaplerProxy` is replaced in the same way as before the fix. And showing that all the build monitoring stuff still works with CSP header set.

[After the fix](https://www.youtube.com/watch?v=SX2T9VSA9nQ)

---

For Google Analytics script I've missed it when recording initially, so covered it separately:

[Before the fix](https://www.youtube.com/watch?v=NxKOtVDIDAM)
[After the fix](https://www.youtube.com/watch?v=QPOrfan_25A)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
