### PR TITLE
Add 'This plugin is changing' button

### DIFF
--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-settings.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-settings.jelly
@@ -1,18 +1,18 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <nav data-ng-controller="controlPanel" data-ng-init="built_at = '${it.installation.buildMonitorBuiltAt()}'; defaults.fontSize = ${it.textScale}; defaults.numberOfColumns = ${it.maxColumns}; defaults.colourBlind = ${it.colourBlindMode}; defaults.reduceMotion = ${it.reduceMotion}; defaults.showBadges = ${it.showBadges}; addCookie()">
-        <span data-ng-show="newVersionAvailable" class="notifications">!</span>
         <section data-ng-class="{ showSettings:toggleSettings }">
             <input id="settings-toggle" type="checkbox" class="settings" data-ng-model="toggleSettings" />
             <label for="settings-toggle" title="Configure Build Monitor Settings">Settings</label>
 
             <!-- workaround for angular-slider not working when initialised within a hidden element -->
             <ul>
-                <li class="new-version-available" data-ng-show="newVersionAvailable">
-                    <h2>Good news :-)</h2>
-                    <p>New version of Build Monitor is&amp;nbsp;<a href="http://bit.ly/JBMReleases" title="Check out the release notes">available now</a>!</p>
-                    <p>Upgrade via <a href="${h.inferHudsonURL(request2)}pluginManager">Plugin Manager</a></p>
-                </li>
+                <a class="jenkins-button jenkins-button--primary bm-revamp"
+                   href="https://github.com/jenkinsci/build-monitor-plugin/pull/1108"
+                   target="_blank">
+                    This plugin is changing
+                    <div>Have your say!</div>
+                </a>
                 <li class="settings-option">
                     <span class="slider-label">Text scale</span>
                     <rzslider rz-slider-model="settings.fontSize" rz-slider-options="{ floor: 0.1, ceil: 5, step: 0.1, precision: 1 }"></rzslider>

--- a/build-monitor-plugin/src/main/webapp/less/index.less
+++ b/build-monitor-plugin/src/main/webapp/less/index.less
@@ -31,3 +31,15 @@
 @import "module/index.less";
 @import "state/index.less";
 @import "theme/index.less";
+
+.bm-revamp {
+  flex-direction: column;
+  width: 184px;
+  padding: 0.5rem;
+  text-align: left;
+  gap: 0.25rem;
+
+  div {
+    opacity: 0.75;
+  }
+}


### PR DESCRIPTION
<img width="282" alt="image" src="https://github.com/user-attachments/assets/69019236-10b1-4c12-a48a-02e1a59e2205" />

Wanted to gather feedback/make users aware ahead of the redesign of the plugin, so added a big blue button to tell users.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
