### PR TITLE
Fix Failure Analyzer plugin display setting

### DIFF
--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
@@ -83,7 +83,7 @@ public class BuildMonitorView extends ListView {
     }
 
     @SuppressWarnings("unused") // used in the configure-entries.jelly form
-    public String currentbuildFailureAnalyzerDisplayedField() {
+    public String currentBuildFailureAnalyzerDisplayedField() {
         return currentConfig().getBuildFailureAnalyzerDisplayedField().getValue();
     }
 

--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
@@ -137,9 +137,9 @@ public class Config implements Describable<Config> {
     // --
 
     public enum BuildFailureAnalyzerDisplayedField {
-        Name("name"),
-        Description("description"),
-        None("none");
+        Name("Name"),
+        Description("Description"),
+        None("None");
 
         private final String value;
 

--- a/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -103,9 +103,9 @@
     <f:entry title="${%Failure Analyzer Plugin: Field to display}" help="${descriptor.getHelpFile('buildFailureAnalyzerDisplayedField')}">
       <div class="jenkins-select">
         <select name="buildFailureAnalyzerDisplayedField" class="jenkins-select__input">
-          <f:option value="Name" selected="${it.currentbuildFailureAnalyzerDisplayedField()=='Name'}">${%Name}</f:option>
-          <f:option value="Description" selected="${it.currentbuildFailureAnalyzerDisplayedField()=='Description'}">${%Description}</f:option>
-          <f:option value="None" selected="${it.currentbuildFailureAnalyzerDisplayedField()=='None'}">${%None}</f:option>
+          <f:option value="Name" selected="${it.currentBuildFailureAnalyzerDisplayedField()=='Name'}">${%Name}</f:option>
+          <f:option value="Description" selected="${it.currentBuildFailureAnalyzerDisplayedField()=='Description'}">${%Description}</f:option>
+          <f:option value="None" selected="${it.currentBuildFailureAnalyzerDisplayedField()=='None'}">${%None}</f:option>
         </select>
       </div>
     </f:entry>


### PR DESCRIPTION
Based on https://github.com/jenkinsci/build-monitor-plugin/pull/330 - with thanks to @jfhumann

Closes https://github.com/jenkinsci/build-monitor-plugin/issues/655

### Testing done

* Setting now saves correctly

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
