### PR TITLE
fix: restore title display in Build Monitor view (fixes #1213)

### DIFF
--- a/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/index.jelly
+++ b/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/index.jelly
@@ -5,17 +5,20 @@
            <l:pageHeader title="${null}"
                          logoAlt="${null}"
                          searchPlaceholder="${null}"
-                         searchHelpUrl="$null}"
+                         searchHelpUrl="${null}"
                          logout="${null}" />
 
            <div id="app"
                 data-build-monitor-id="${it.displayName.hashCode()}"
+                data-build-monitor-title="${it.title}"
                 data-build-monitor-description="${it.description}"
                 data-appearance-text-size="${it.textScale}"
                 data-appearance-maximum-number-of-columns="${it.maxColumns}"
                 data-appearance-color-blind-mode="${it.colourBlindMode}"
                 data-appearance-show-badges="${it.showBadges}"
                 data-auto-refresh-every="${it.autoRefreshEvery}" />
+
+           <h1 id="build-monitor-title">${it.title}</h1>
 
            <script src="${rootURL}/plugin/build-monitor-plugin/js/bundles/app.js" type="module" />
        </l:main-panel>


### PR DESCRIPTION
## Summary

Fixes #1213 — The Build Monitor view title (including unicode/emoji characters) was no longer being displayed on the monitor view page.

## Root Cause

The title rendering was missing from `index.jelly`. The title field is correctly saved via `configure-entries.jelly` and exposed through `BuildMonitorView.java`, but it was not being rendered in the view template.

## Changes

- **Only file modified:** `build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/index.jelly`
- Restored the title display element so `${it.title}` is rendered on the monitor page, supporting unicode characters as before.

## Testing

- Configured a Build Monitor view with a title containing unicode characters (e.g. Surveillance)
- Verified the title appears on the view page after saving
- Verified no other functionality is affected