### PR TITLE
fixed build retrieval when Display Commiters enabled and a Pipeline build is triggered from a Freestyle one

### DIFF
--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/culprits/BuildCulpritsRetriever.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/culprits/BuildCulpritsRetriever.java
@@ -12,14 +12,19 @@ import java.util.Set;
  */
 public abstract class BuildCulpritsRetriever {
 
+    private StaticJenkinsAPIs staticJenkinsAPIs;
+
     public static BuildCulpritsRetriever getInstanceForRun(Run<?, ?> run, StaticJenkinsAPIs staticJenkinsAPIs) {
+        BuildCulpritsRetriever retriever;
         if (PipelineHelper.isWorkflowRun(run, staticJenkinsAPIs)) {
-            return new BuildCulpritsWorkflowRun();
+            retriever = new BuildCulpritsWorkflowRun();
         } else if (run instanceof AbstractBuild) {
-            return new BuildCulpritsAbstractBuild();
+            retriever = new BuildCulpritsAbstractBuild();
         } else {
-            return new BuildCulpritsNotImplemented();
+            retriever = new BuildCulpritsNotImplemented();
         }
+        retriever.staticJenkinsAPIs = staticJenkinsAPIs;
+        return retriever;
     }
 
     public abstract Set<String> getCulprits(Run<?, ?> run);
@@ -34,7 +39,10 @@ public abstract class BuildCulpritsRetriever {
             if (upstreamCause != null) {
                 Run<?, ?> upstreamRun = upstreamCause.getUpstreamRun();
                 if (upstreamRun != null) {
-                    committers.addAll(getCommitters(upstreamRun));
+                    // Use the correct retriever for the upstream run type — it may differ from this one
+                    // (e.g. a Pipeline triggered by a FreeStyleProject).
+                    BuildCulpritsRetriever upstreamRetriever = getInstanceForRun(upstreamRun, staticJenkinsAPIs);
+                    committers.addAll(upstreamRetriever.getCommitters(upstreamRun));
                 }
             }
         }

--- a/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/culprits/BuildCulpritsRetrieverTest.java
+++ b/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/culprits/BuildCulpritsRetrieverTest.java
@@ -1,0 +1,140 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.culprits;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.facade.StaticJenkinsAPIs;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.pipeline.PipelineHelper;
+import hudson.Plugin;
+import hudson.model.AbstractBuild;
+import hudson.model.Cause;
+import hudson.model.User;
+import hudson.scm.ChangeLogSet;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class BuildCulpritsRetrieverTest {
+
+    private MockedStatic<Jenkins> mockedJenkins;
+    private StaticJenkinsAPIs staticJenkinsAPIs;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // PipelineHelper caches class-lookup results in static fields; reset between tests
+        // to prevent ordering-dependent failures.
+        resetPipelineHelperCache();
+
+        mockedJenkins = mockStatic(Jenkins.class);
+        Jenkins jenkins = mock(Jenkins.class);
+        mockedJenkins.when(Jenkins::get).thenReturn(jenkins);
+        when(jenkins.getPlugin("workflow-job")).thenReturn(mock(Plugin.class));
+        staticJenkinsAPIs = new StaticJenkinsAPIs();
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedJenkins.close();
+    }
+
+    @Test
+    void getCommitters_follows_upstream_cause_to_freestyle_build_without_throwing() {
+        // Regression test: previously threw ClassCastException because
+        // BuildCulpritsWorkflowRun.getCommittersForRun was used on the upstream FreeStyleBuild.
+
+        // Build the ChangeLogSet before opening any Mockito stubbing: changeSetWith() calls
+        // mock() internally, which conflicts with an already-open when().thenReturn() chain.
+        ChangeLogSet<?> aliceSet = changeSetWith("Alice");
+        AbstractBuild<?, ?> upstreamBuild = mock(AbstractBuild.class);
+        doReturn(aliceSet).when(upstreamBuild).getChangeSet();
+        when(upstreamBuild.getCause(Cause.UpstreamCause.class)).thenReturn(null);
+
+        WorkflowRun pipelineRun = pipelineRunWithNoCommitters();
+        Cause.UpstreamCause upstreamCause = mock(Cause.UpstreamCause.class);
+        doReturn(upstreamBuild).when(upstreamCause).getUpstreamRun();
+        when(pipelineRun.getCause(Cause.UpstreamCause.class)).thenReturn(upstreamCause);
+
+        Set<String> committers = BuildCulpritsRetriever.getInstanceForRun(pipelineRun, staticJenkinsAPIs)
+                .getCommitters(pipelineRun);
+
+        assertThat(committers, containsInAnyOrder("Alice"));
+    }
+
+    @Test
+    void getCommitters_returns_pipeline_own_committers_without_following_upstream() {
+        WorkflowRun pipelineRun = mock(WorkflowRun.class);
+        setChangeSets(pipelineRun, changeSetWith("Bob"));
+
+        Set<String> committers = BuildCulpritsRetriever.getInstanceForRun(pipelineRun, staticJenkinsAPIs)
+                .getCommitters(pipelineRun);
+
+        assertThat(committers, containsInAnyOrder("Bob"));
+    }
+
+    @Test
+    void getCommitters_returns_empty_when_freestyle_build_has_no_committers_and_no_upstream() {
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        when(build.getChangeSet()).thenReturn(null);
+        when(build.getCause(Cause.UpstreamCause.class)).thenReturn(null);
+
+        Set<String> committers = BuildCulpritsRetriever.getInstanceForRun(build, staticJenkinsAPIs)
+                .getCommitters(build);
+
+        assertThat(committers, empty());
+    }
+
+    private WorkflowRun pipelineRunWithNoCommitters() {
+        WorkflowRun run = mock(WorkflowRun.class);
+        when(run.getChangeSets()).thenReturn(List.of());
+        return run;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void setChangeSets(WorkflowRun run, ChangeLogSet changeSet) {
+        when(run.getChangeSets()).thenReturn(List.of(changeSet));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private ChangeLogSet changeSetWith(String... authorNames) {
+        List<ChangeLogSet.Entry> entries = new ArrayList<>();
+        for (String name : authorNames) {
+            User user = mock(User.class);
+            when(user.getFullName()).thenReturn(name);
+            ChangeLogSet.Entry entry = mock(ChangeLogSet.Entry.class);
+            when(entry.getAuthor()).thenReturn(user);
+            entries.add(entry);
+        }
+        return new ChangeLogSet(null, null) {
+            @Override
+            public boolean isEmptySet() {
+                return entries.isEmpty();
+            }
+
+            @Override
+            public Iterator iterator() {
+                return entries.iterator();
+            }
+        };
+    }
+
+    private static void resetPipelineHelperCache() throws Exception {
+        for (String fieldName : List.of("hasWorkflowClass", "workflowRunClass")) {
+            Field field = PipelineHelper.class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(null, null);
+        }
+    }
+}


### PR DESCRIPTION
BuildCulpritsRetriever.getCommitters() follows UpstreamCause chains to find committers. The recursive call reused `this` (BuildCulpritsWorkflowRun) even when the upstream run was a FreeStyleBuild, causing an unconditional cast to WorkflowRun to blow up.

Fix: store StaticJenkinsAPIs on the retriever and use getInstanceForRun() when following upstream causes, so each run gets the correct retriever for its type.

Fixes #1259

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
Checked that Build Monitor fails with a Pipeline build triggered from a FreeStyle build with "Display committers" enabled.
Disabled "Display committers" and verified the Build Monitor shows all the builds.
Built & uploaded HPI to Jenkins. 
Check that Build Monitor doesn't fail when I enable "Display committers".

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
