### PR TITLE
Wrap long job names and badges instead of being clipped.

### DIFF
--- a/src/main/frontend/styles/_cell.scss
+++ b/src/main/frontend/styles/_cell.scss
@@ -24,6 +24,7 @@ $cell-padding: 1rem;
   outline: none;
   overflow: hidden;
   text-align: center;
+  overflow-wrap: anywhere;
   color: var(
     --bm-contrast,
     color-mix(in srgb, var(--bm-cell-color) 75%, var(--text-color))

--- a/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/e2e/ShouldWrapLongJobNamesTest.java
+++ b/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/e2e/ShouldWrapLongJobNamesTest.java
@@ -1,0 +1,38 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.e2e;
+
+import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.e2e.utils.BuildMonitorViewUtils.createBuildMonitorView;
+import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.e2e.utils.FreeStyleProjectUtils.createFreeStyleProject;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.junit.UsePlaywright;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.e2e.config.PlaywrightConfig;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.e2e.pages.BuildMonitorViewPage;
+import hudson.model.Result;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+@UsePlaywright(PlaywrightConfig.class)
+class ShouldWrapLongJobNamesTest {
+
+    // too long for one line, differing only in the separator they use
+    private static final List<String> NAMES = List.of(
+            "MyOrganization-MyTeam-MyApplication-MyJob-with-long-name",
+            "MyOrganization.MyTeam.MyApplication.MyJob-with-long-name",
+            "MyOrganization_MyTeam_MyApplication_MyJob-with-long-name",
+            "MyOrganization MyTeam MyApplication MyJob with long name",
+            "MyOrganizationMyTeamMyApplicationMyJobWithLongName");
+
+    @Test
+    void test(Page p, JenkinsRule j) {
+        NAMES.forEach(name -> createFreeStyleProject(j, name).run(Result.SUCCESS));
+        var view = createBuildMonitorView(j, "Build Monitor").displayAllProjects();
+
+        var monitor = BuildMonitorViewPage.from(p, view).goTo();
+
+        NAMES.forEach(
+                name -> monitor.getJob(name).hasNameWrappedOntoMultipleLines().hasNameContainedWithinCell());
+    }
+}

--- a/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/e2e/pages/JobComponent.java
+++ b/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/e2e/pages/JobComponent.java
@@ -62,6 +62,49 @@ public class JobComponent {
         return this;
     }
 
+    public JobComponent hasNameContainedWithinCell() {
+        Locator heading = component.locator("h2");
+
+        Number overflow = (Number) heading.evaluate("heading => {"
+                + "  const bounds = heading.closest('.bm-cell').getBoundingClientRect();"
+                + "  const name = heading.getBoundingClientRect();"
+                + "  return Math.max(bounds.left - name.left, name.right - bounds.right, 0);"
+                + "}");
+
+        if (overflow.doubleValue() > 0.5) {
+            throw new AssertionError(
+                    "Job name '" + heading.textContent() + "' overflows its cell by " + overflow + "px");
+        }
+
+        return this;
+    }
+
+    public JobComponent hasNameWrappedOntoMultipleLines() {
+        Locator heading = component.locator("h2");
+
+        Number lines = (Number) heading.evaluate("heading => {"
+                + "  const walker = document.createTreeWalker(heading, NodeFilter.SHOW_TEXT);"
+                + "  const tops = new Set();"
+                + "  let node;"
+                + "  while ((node = walker.nextNode())) {"
+                + "    for (let i = 0; i < node.textContent.length; i++) {"
+                + "      const range = document.createRange();"
+                + "      range.setStart(node, i);"
+                + "      range.setEnd(node, i + 1);"
+                + "      tops.add(Math.round(range.getBoundingClientRect().top));"
+                + "    }"
+                + "  }"
+                + "  return tops.size;"
+                + "}");
+
+        if (lines.intValue() < 2) {
+            throw new AssertionError(
+                    "Job name '" + heading.textContent() + "' fits on one line, so it no longer exercises wrapping");
+        }
+
+        return this;
+    }
+
     public JobComponent hasStage(String stage) {
         assertThat(component).containsText(stage);
         return this;


### PR DESCRIPTION
Long job names and badges now wrap instead of being clipped.

Fixes #1332. Browsers only break lines at spaces and hyphens, so a name like
`MyOrganization.MyTeam.MyApplication` is treated as one unbreakable word and
was cut off at both ends of the cell.

The fix is one CSS declaration:

```scss
overflow-wrap: anywhere;
```

It sits on `.bm-cell` rather than the heading, so it covers both the job name
and the badges, which had the same problem. No new settings, no markup changes.

This is deliberately minimal change: text now stays inside the cell, but a break can
land mid-word. More fine-grained wrapping is possible by inserting `<wbr/>`
hints after each word separator (such "_", ":", ".",...), so a name breaks at preferred
locations rather than mid-word. That needs a small amount of JavaScript in the cell
component, so it is left out of this fix and can be added later if the mid-word breaks
prove annoying.

### Testing done

New end-to-end test `ShouldWrapLongJobNamesTest` renders five long names in a
real browser — hyphenated, dotted, underscored, space-separated and one with no
separators — and asserts each wraps onto more than one line and stays inside its
cell. Both assertions were checked against a broken state, so neither can pass
by accident.

`mvn verify` passes on Windows with JDK 21: 100 Java tests, 3 frontend tests,
0 failures.

Also checked manually against a local Jenkins with those five names, each with a
long badge in a matching separator style: clipped before, contained after.

### Screenshots

Before fix:
<img width="1762" height="317" alt="Screenshot 2026-08-24 022612" src="https://github.com/user-attachments/assets/18737e29-7c19-4e6c-8abf-820f5588b742" />

After fix:
<img width="1764" height="321" alt="Screenshot 2026-08-24 022132" src="https://github.com/user-attachments/assets/0c394c20-d8ab-4733-9722-95275f310582" />

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed